### PR TITLE
WS-1122: removes undeeded title attribute. fixes #12

### DIFF
--- a/templates/block--ucla-gateway-branding.html.twig
+++ b/templates/block--ucla-gateway-branding.html.twig
@@ -23,7 +23,7 @@
 </div>
   {% endif %}
   {% if site_name %}
-    <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home">Home</a>
+    <a href="{{ path('<front>') }}" rel="home">Home</a>
   {% endif %}
   {{ site_slogan }}
 {% endblock %}


### PR DESCRIPTION
* according to http://asqatasun.github.io/RGAA--3.0--EN/RGAA3.0_Glossary_English_version_v1.html#mTitreLien link title attributes should not match the full text of the link