### PR TITLE
WS-1122: removes Home link when logo is present

### DIFF
--- a/templates/block--ucla-gateway-branding.html.twig
+++ b/templates/block--ucla-gateway-branding.html.twig
@@ -21,9 +21,8 @@
       <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" />
     </a>
 </div>
-  {% endif %}
-  {% if site_name %}
-    <a href="{{ path('<front>') }}" rel="home">Home</a>
+  {% elseif site_name %}
+    <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home">{{ site_name }}</a>
   {% endif %}
   {{ site_slogan }}
 {% endblock %}


### PR DESCRIPTION
It turns out that making a Home link directly next to the logo is looked at from the AIM wave tool as a redundant link, which it is. 

This change fixes #15 by conditionally printing this link based if a logo is being used or not. This link is also not empty and contains the site title so it can retain the title attribute.